### PR TITLE
API.waitForElementPresent bug

### DIFF
--- a/lib/waitForXHR.js
+++ b/lib/waitForXHR.js
@@ -26,7 +26,7 @@ WaitForXHR.prototype.command = function (requestURL, timeout_wait_in_ms, callbac
   requestURL = requestURL || '';
 
 
-  self.api.waitForElementPresent("html");
+  self.api.waitForElementPresent("html", timeout_wait_in_ms);
   self.api.execute(function (windowRequestURL, windowResponseContainer, timeout_wait_in_ms) {
     var waitForXHRResponse = function (requestURL, callback_waitForXHRResponse, timeout) {
       XMLHttpRequest.waiting_xhr_url = new RegExp(requestURL);


### PR DESCRIPTION
Adds a missing timeout argument in `waitForElementPresent`.