### PR TITLE
fix: Correct error message in case given non-string requestUrl

### DIFF
--- a/lib/waitForXHR.js
+++ b/lib/waitForXHR.js
@@ -13,18 +13,17 @@ WaitForXHR.prototype.command = function (requestURL, timeout_wait_in_ms, callbac
 
   //console.log('BEGIN WaitForXHR', responseContainer);
   var self = this;
-  if (requestURL && typeof  requestURL != "string") {
+  if (requestURL && typeof requestURL != "string") {
+    throw new Error("requestURL should be empty or string");
+  }
+  if (trigger && typeof trigger != "function") {
     throw new Error("trigger should be empty or function");
   }
-  if (trigger && typeof  trigger != "function") {
-    throw new Error("trigger should be empty or function");
-  }
-
   if (callback_WaitForXHR && typeof callback_WaitForXHR != 'function') {
     throw new Error('callback_WaitForXHR should be a function');
   }
+  
   requestURL = requestURL || '';
-
 
   self.api.waitForElementPresent("html", timeout_wait_in_ms);
   self.api.execute(function (windowRequestURL, windowResponseContainer, timeout_wait_in_ms) {


### PR DESCRIPTION
Was complaining about trigger argument, when it was actually requestUrl who was not of the right type.