### PR TITLE
Add Babel compilation on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "nightwatch-xhr",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "An XHR \"Listener\" for Nightwatch.js",
   "main": "lib/waitForXHR.js",
   "scripts": {
+    "install": "npm run-script build",
     "build": "babel src --out-dir es5 --copy-files --delete-dir-on-start",
     "build:watch": "babel src --out-dir es5 --copy-files --delete-dir-on-start --watch",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "install": "npm run-script build",
     "build": "babel src --out-dir es5 --copy-files --delete-dir-on-start",
-    "build:watch": "babel src --out-dir es5 --copy-files --delete-dir-on-start --watch",
+    "build:watch":
+      "babel src --out-dir es5 --copy-files --delete-dir-on-start --watch",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:watch:verbose": "jest --watch --verbose",
@@ -16,12 +17,7 @@
     "type": "git",
     "url": "git+https://github.com/cortexmg/nightwatch-xhr.git"
   },
-  "keywords": [
-    "ajax",
-    "xhr",
-    "nightwatchjs",
-    "nightwatch"
-  ],
+  "keywords": ["ajax", "xhr", "nightwatchjs", "nightwatch"],
   "author": "orzilca <orzilca@gmail.com> (https://github.com/orzilca)",
   "license": "MIT",
   "bugs": {
@@ -30,22 +26,22 @@
   "homepage": "https://github.com/cortexmg/nightwatch-xhr#readme",
   "jest": {
     "testRegex": "test/([^/]+/?){2}\\.js$",
-    "moduleFileExtensions": [
-      "js"
-    ],
+    "moduleFileExtensions": ["js"],
     "transform": {
       "^.+\\.js$": "babel-jest"
     }
   },
-  "devDependencies": {
+  "dependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "6",
-    "babel-jest": "^21.2.0",
-    "babel-plugin-dynamic-import-node": "^1.1.0",
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-flow": "^6.23.0",
-    "flow-bin": "^0.56.0",
+    "babel-plugin-dynamic-import-node": "^1.1.0",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "flow-bin": "^0.56.0"
+  },
+  "devDependencies": {
+    "babel-jest": "^21.2.0",
     "jest": "^21.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "install": "npm run-script build",
     "build": "babel src --out-dir es5 --copy-files --delete-dir-on-start",
-    "build:watch":
-      "babel src --out-dir es5 --copy-files --delete-dir-on-start --watch",
+    "build:watch": "babel src --out-dir es5 --copy-files --delete-dir-on-start --watch",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:watch:verbose": "jest --watch --verbose",
@@ -17,7 +16,12 @@
     "type": "git",
     "url": "git+https://github.com/cortexmg/nightwatch-xhr.git"
   },
-  "keywords": ["ajax", "xhr", "nightwatchjs", "nightwatch"],
+  "keywords": [
+    "ajax",
+    "xhr",
+    "nightwatchjs",
+    "nightwatch"
+  ],
   "author": "orzilca <orzilca@gmail.com> (https://github.com/orzilca)",
   "license": "MIT",
   "bugs": {
@@ -26,7 +30,9 @@
   "homepage": "https://github.com/cortexmg/nightwatch-xhr#readme",
   "jest": {
     "testRegex": "test/([^/]+/?){2}\\.js$",
-    "moduleFileExtensions": ["js"],
+    "moduleFileExtensions": [
+      "js"
+    ],
     "transform": {
       "^.+\\.js$": "babel-jest"
     }


### PR DESCRIPTION
Fix for issue #9.

 - Add an install NPM script to run after install
 - Transfer Babel dependencies from devDependencies to dependencies (required for build on install)