### PR TITLE
feat: Change getXHR behavior to wait until the end of delay before callback

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -45,5 +45,5 @@ export const clientListen = function () {
 };
 
 export const clientPoll = function () {
-    return window.xhrListen;
+    return window.xhrListen || [];
 };

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -16,7 +16,7 @@ export type ListenedXHR = {|
    requestData?: string,
 |};
 
-export type Callback = (ListenedXHR => void);
+export type Callback = (Array<ListenedXHR> => void);
 export type Trigger = string | () => void;
 
 export type Options = {|


### PR DESCRIPTION
Sometime, you may want to verify that no XHR call has been made. Or that 2 XHR calls have been made. 
 
In order to do that, getXHR should wait until the end of the given delay, if any, and returns all the catched requests, event if that means an empty array. It should not fail if no request have been catched. 

This is why I propose this. 