### PR TITLE
chore: Use prepare script instead of build on install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 npm-debug.log
-.idea
+.idea/
 coverage
+es5/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+test/
+yarn.lock
+.gitignore
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+coverage
+node_modules/
+.npm
+.yarn-integrity
+flow-typed/
+.flowconfig

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "An XHR \"Listener\" for Nightwatch.js",
   "main": "lib/waitForXHR.js",
   "scripts": {
-    "install": "npm run-script build",
-    "build": "babel src --out-dir es5 --copy-files --delete-dir-on-start",
+    "prepare": "babel src --out-dir es5 --copy-files --delete-dir-on-start",
     "build:watch": "babel src --out-dir es5 --copy-files --delete-dir-on-start --watch",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -37,17 +36,15 @@
       "^.+\\.js$": "babel-jest"
     }
   },
-  "dependencies": {
+  "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "6",
+    "babel-jest": "^21.2.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-flow": "^6.23.0",
     "babel-plugin-dynamic-import-node": "^1.1.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "flow-bin": "^0.56.0"
-  },
-  "devDependencies": {
-    "babel-jest": "^21.2.0",
+    "flow-bin": "^0.56.0",
     "jest": "^21.2.1"
   }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/cortexmg/nightwatch-xhr/pull/10

I'm really not fond of having dev dependencies marked as dependencies because it can bring a loooooooooooot of useless dependencies on a (maybe otherwise light) project. 

Moreover, it means that ES5 files will be rebuild on each npm/yarn install/update, even if the project is using the es6/7 files directly. 

That is why I propose to simply use the NPM `prepare` script which will build ES5 files automatically at publish time. That way, ES5 are published on NPM along  ES6/7 files, and there is no need to build them on the developer machine. 
And we can keep dev dependencies as devDependencies, and they will not be installed, so that it stays a 'zero dependency' module. 

Happy to discuss my solution. 