### PR TITLE
Bugfix Issue#19: XHR Callback functions - we are not getting the response code, data 

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -24,7 +24,7 @@ export const clientListen = function () {
                 url,
                 openedTime: Date.now(),
             });
-            this.onload = function () {
+            this.onloadend = function () {
                 if (this.readyState === XMLHttpRequest.DONE) {
                     const xhr = getXhr(this.id);
                     if (xhr) {


### PR DESCRIPTION
Response data was not being populated using 
XMLHttpRequestEventTarget.onload

I believe this to be due to onload only returning after successful fetch. WHere as onloadend can return xhr data even if some of the requests fail.

Prior to the change only fields
id:  method: openedTime: and requestData were populated if status on any of the xhr were 'error'
Now responseData, status and response code fields populate as expected.